### PR TITLE
Add command line and size count into botinfo.js

### DIFF
--- a/src/commands/botinfo.js
+++ b/src/commands/botinfo.js
@@ -1,7 +1,41 @@
 const Discord = require(`discord.js`),
       cpuStat = require(`cpu-stat`),
       os = require(`os`),
+      fs = require(`fs`),
       config = require(`../config.json`);
+
+let commandLines = moduleLines = botLines
+    = commandSize = moduleSize = botSize 
+    = 0;
+
+fs.readdir(`./commands/`, (error, files) => {
+    if(error) throw `Error counting command size: ${error}`;
+
+    files.forEach(file => {
+        const cont = fs.readFileSync(`./commands/${file}`, {encoding:`utf8`});
+        commandLines += cont.split(`\n`).length;
+        commandSize += fs.statSync(`./commands/${file}`).size/1000;
+    });
+
+    commandSize = Math.round(commandSize * 10) / 10;
+});
+
+fs.readdir(`./modules/`, (error, files) => {
+    if(error) throw `Error counting module size: ${error}`;
+
+    files.forEach(file => {
+        const cont = fs.readFileSync(`./modules/${file}`, {encoding:`utf8`});
+        moduleLines += cont.split(`\n`).length;
+        moduleSize += fs.statSync(`./modules/${file}`).size/1000;
+    });
+
+    moduleSize = Math.round(moduleSize * 10) / 10;
+});
+
+const cont = fs.readFileSync(`./bot.js`, {encoding:`utf8`});
+botLines += cont.split(`\n`).length;
+botSize += fs.statSync(`./bot.js`).size/1000;
+botSize = Math.round(botSize * 10) / 10
 
 function formatBytes(a, b) {
     let c = 1024;
@@ -42,7 +76,10 @@ module.exports.run = (bot, message, args) => {
             .addField('Memory Usage: ', memoryusage, true)
             .addField('CPU Usage: ', `${cpu}%`, true)
             .addField('CPU Model: ', cpuModel)
-            .addField('Cores: ', `${cores}`, true);
+            .addField('Cores: ', `${cores}`)
+            .addField('Bot file: ', `${botLines} lines (${botSize}KB)`, true)
+            .addField('Module files: ', `${moduleLines} lines (${moduleSize}KB)`, true)
+            .addField('Command files: ', `${commandLines} lines (${commandSize}KB)`, true);
 
         message.channel.send({ embeds: [embed] });
     });


### PR DESCRIPTION
pretty self-explanatory
calculates everything on command load, and rounds file sizes to 1dp

visible below

![image](https://user-images.githubusercontent.com/40303296/150424502-29ef4af5-4c14-408a-9183-8d3b84d15129.png)
